### PR TITLE
Remove inline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ These functions work together to:
 3. Save frames as PNG images.
 4. Convert timestamps to human-readable formats.
 5. Write `.ser` files with the desired frames, metadata, and timestamps.
+
+See `examples/extract_frames_example.py` for a walkthrough of selecting a
+subset of frames from an existing SER file and saving them to a new file.

--- a/examples/extract_frames_example.py
+++ b/examples/extract_frames_example.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+# Add the parent directory of the examples folder to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Now import serPy
+import serPy
+
+# Read an existing SER file
+metadata, frames, timestamps = serPy.read_ser("TestImages/jup.ser")
+
+# Select a subset of frames
+selected_frames = frames[10:20]
+selected_timestamps = timestamps[10:20] if timestamps else None
+metadata["frame_count"] = len(selected_frames)
+
+# Write the new SER file
+serPy.write_ser(
+    "output.ser",
+    metadata,
+    selected_frames,
+    selected_timestamps
+)
+
+# Save a sample frame as PNG
+serPy.save_frame_as_png(frames[0], "test.png", metadata["color_id"])

--- a/serPy/serPy.py
+++ b/serPy/serPy.py
@@ -244,19 +244,3 @@ def read_ser(input_path):
             timestamps = None
 
     return metadata, frames, timestamps
-"""
-# Example: Extract and save specific frames
-metadata, frames, timestamps = read_ser("TestImages/jup.ser")
-selected_frames = frames[10:20]
-selected_timestamps = timestamps[10:20] if timestamps else None
-metadata["frame_count"]=len(selected_frames)
-
-write_ser(
-    "output.ser",
-    metadata,
-    selected_frames,
-    selected_timestamps
-)
-
-save_frame_as_png(frames[0],"test.png",metadata["color_id"])
-"""


### PR DESCRIPTION
## Summary
- remove inline example from `serPy.py`
- provide a standalone example script
- reference the example in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684215851a7483238bac3d84d7e096bf