### PR TITLE
Add round-trip SER reader/writer test

### DIFF
--- a/serPy/serPy.py
+++ b/serPy/serPy.py
@@ -201,8 +201,12 @@ def read_ser(input_path):
             raise ValueError("Invalid SER file: Incorrect File ID.")
 
         # Prepare metadata
+        # Helper to decode fixed-width string fields without trailing null bytes
+        def _decode_field(value: bytes) -> str:
+            return value.decode("utf-8").rstrip("\x00").strip()
+
         metadata = {
-            "file_id": file_id.decode("utf-8").strip(),
+            "file_id": _decode_field(file_id),
             "lu_id": lu_id,
             "color_id": color_id,
             "little_endian": bool(little_endian),
@@ -210,9 +214,9 @@ def read_ser(input_path):
             "image_height": image_height,
             "pixel_depth": pixel_depth,
             "frame_count": frame_count,
-            "observer": observer.decode("utf-8").strip(),
-            "instrument": instrument.decode("utf-8").strip(),
-            "telescope": telescope.decode("utf-8").strip(),
+            "observer": _decode_field(observer),
+            "instrument": _decode_field(instrument),
+            "telescope": _decode_field(telescope),
             "date_time": struct.unpack("<Q", date_time)[0],
             "date_time_utc": struct.unpack("<Q", date_time_utc)[0],
         }

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -1,0 +1,40 @@
+import sys
+import os
+
+# Ensure the package is importable when running tests directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import numpy as np
+import serPy
+
+
+def test_write_and_read_ser(tmp_path):
+    width, height, nframes = 5, 4, 3
+    metadata = {
+        "file_id": "LUCAM-RECORDER",
+        "lu_id": 1,
+        "color_id": 0,
+        "little_endian": True,
+        "image_width": width,
+        "image_height": height,
+        "pixel_depth": 8,
+        "frame_count": nframes,
+        "observer": "Tester",
+        "instrument": "TestCam",
+        "telescope": "TestScope",
+        "date_time": 637738597820000000,
+        "date_time_utc": 637738597820000000,
+    }
+    frames = [np.random.randint(0, 256, (height, width), dtype=np.uint8) for _ in range(nframes)]
+    timestamps = [metadata["date_time"] + i for i in range(nframes)]
+
+    ser_file = tmp_path / "temp.ser"
+    serPy.write_ser(str(ser_file), metadata, frames, timestamps)
+
+    read_metadata, read_frames, read_timestamps = serPy.read_ser(str(ser_file))
+
+    assert read_metadata == metadata
+    assert len(read_frames) == len(frames)
+    for orig, loaded in zip(frames, read_frames):
+        assert np.array_equal(orig, loaded)
+    assert read_timestamps == timestamps


### PR DESCRIPTION
## Summary
- add pytest that writes a SER file with `write_ser` and reads it back using `read_ser`
- fix `read_ser` to strip trailing null bytes from string fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842159326108323bcb50090c82c2572