### PR TITLE
Add install and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,23 @@ These functions work together to:
 
 See `examples/extract_frames_example.py` for a walkthrough of selecting a
 subset of frames from an existing SER file and saving them to a new file.
+
+---
+
+### **Installing Requirements and Running Tests**
+
+1. Install the project dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Using `opencv-python-headless` instead of `opencv-python` avoids needing
+   system libraries such as `libGL1`:
+   ```bash
+   pip install opencv-python-headless
+   ```
+
+2. Run the tests with [pytest](https://pytest.org):
+   ```bash
+   pytest
+   ```
+


### PR DESCRIPTION
## Summary
- document how to install requirements
- add instructions on running tests with pytest
- mention using `opencv-python-headless` to avoid libGL1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810ebefca48323a235c2880b4d0e5d